### PR TITLE
(Hopefully) correct copying of styleguide assets to public/

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,11 +70,9 @@ gulp.task('pl-copy:css', function(){
 
 // Styleguide Copy
 gulp.task('pl-copy:styleguide', function(){
-  return gulp.src(
-      ['**/*'],
-      {cwd: path.resolve(paths().source.styleguide)})
-      .pipe(gulp.dest(path.resolve(paths().public.styleguide)))
-      .pipe(browserSync.stream());
+  return gulp.src(path.resolve(paths().source.styleguide, '**/*'))
+    .pipe(gulp.dest(path.resolve(paths().public.root)))
+    .pipe(browserSync.stream());
 });
 
 


### PR DESCRIPTION
Brian -- I think we have to copy to the public root rather than the styleguide path, because the contents of `styleguidekit-assets-default/dist` look like this:
![screen shot 2016-05-19 at 12 59 44 pm](https://cloud.githubusercontent.com/assets/76232/15404182/ea51d752-1dc1-11e6-9eb8-216a54211249.png)

That seems to get everything working for me. Does that make sense to you?
