### PR TITLE
Dodge underscore bug by default

### DIFF
--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -59,5 +59,10 @@
   "patternExportPatternPartials": [],
   "patternExportDirectory": "./pattern_exports/",
   "cacheBust": true,
-  "starterkitSubDir": "dist"
+  "starterkitSubDir": "dist",
+  "outputFileSuffixes": {
+    "rendered": "",
+    "rawTemplate": "",
+    "markupOnly": ".markup-only"
+  }
 }

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -61,7 +61,7 @@
   "cacheBust": true,
   "starterkitSubDir": "dist",
   "outputFileSuffixes": {
-    "rendered": "",
+    "rendered": ".rendered",
     "rawTemplate": "",
     "markupOnly": ".markup-only"
   }


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #69 

Summary of changes:
Super simple change to add default configuration that dodges the problem with underscore templates having the `.html` as a file extension.
