### PR TITLE
Dodge underscore bug by default

### DIFF
--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -61,7 +61,7 @@
   "cacheBust": true,
   "starterkitSubDir": "dist",
   "outputFileSuffixes": {
-    "rendered": "",
+    "rendered": ".rendered",
     "rawTemplate": "",
     "markupOnly": ".markup-only"
   }


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Take 2! Now pointed at dev.

Addresses #69 

Summary of changes:
Super simple change to add default configuration that dodges the problem with underscore templates having the `.html` as a file extension.
