### PR TITLE
add npm script to run local gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "bugs": "https://github.com/pattern-lab/edition-node-gulp/issues",
   "author": "Brian Muenzenmeyer",
   "scripts": {
+    "gulp": "gulp -- ",
     "postinstall": "node node_modules/patternlab-node/core/scripts/postinstall.js"
   },
   "license": "MIT",


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses "Annoying to run local version of gulp"

Summary of changes: 
- Added an npm script that simply runs the local version of gulp.
  - Instead of typing `node_modules/gulp/bin/gulp.js`, you can type `npm run gulp`
  - It also takes arguments the same way as regular gulp, ex: `npm run gulp patternlab:serve`
  - This has no apparent downsides besides 2 extra lines of logs in every call

![gulp default](https://puu.sh/qQnBh/15ccfab275.png)

![with params](https://puu.sh/qQo2x/df3a83caef.png)
