### PR TITLE
Postinstall error prevents use of edition-node-gulp (v1.3.1) as a dep…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": "https://github.com/pattern-lab/edition-node-gulp/issues",
   "author": "Brian Muenzenmeyer",
   "scripts": {
-    "postinstall": "node node_modules/patternlab-node/core/scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js"
   },
   "license": "MIT",
   "engines": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,5 @@
+"use strict";
+console.log('Beginning Pattern Lab Node Gulp postinstall...');
+
+//call the core library postinstall
+var patternlab = require('patternlab-node/core/scripts/postinstall');


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #77 

Summary of changes:
- replaces nested postinstall with own postinstall that better calls core postinstall. 
