### PR TITLE
Watching reliability, async build support, npm start

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "builtin": true
+    "builtin": true,
+    "es6": true
   },
   "globals": {},
   "rules": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,15 +97,16 @@ function getConfiguredCleanOption() {
 }
 
 /**
- *
+ * Performs the actual build step. Accomodates both async and sync
+ * versions of Pattern Lab.
  * @param {function} done - Gulp done callback
  */
 function build(done) {
-  const buildPromise = patternlab.build(() => {}, getConfiguredCleanOption());
+  const buildResult = patternlab.build(() => {}, getConfiguredCleanOption());
 
   // handle async version of Pattern Lab
-  if (buildPromise instanceof Promise) {
-    return buildPromise.then(done);
+  if (buildResult instanceof Promise) {
+    return buildResult.then(done);
   }
 
   // handle sync version of Pattern Lab

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,8 +79,8 @@ function getConfiguredCleanOption() {
   return config.cleanPublic;
 }
 
-function build(done) {
-  patternlab.build(done, getConfiguredCleanOption());
+function build() {
+  return patternlab.build(() => {}, getConfiguredCleanOption());
 }
 
 gulp.task('pl-assets', gulp.series(
@@ -122,9 +122,7 @@ gulp.task('patternlab:loadstarterkit', function (done) {
   done();
 });
 
-gulp.task('patternlab:build', gulp.series('pl-assets', build, function(done){
-  done();
-}));
+gulp.task('patternlab:build', gulp.series('pl-assets', build));
 
 gulp.task('patternlab:installplugin', function (done) {
   patternlab.installplugin(argv.plugin);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,47 +16,47 @@ function resolvePath(pathInput) {
  * COPY TASKS - stream assets from source to destination
 ******************************************************/
 // JS copy
-gulp.task('pl-copy:js', function(){
   return gulp.src('**/*.js', {cwd: resolvePath(paths().source.js)} )
     .pipe(gulp.dest(resolvePath(paths().public.js)));
+gulp.task('pl-copy:js', function () {
 });
 
 // Images copy
-gulp.task('pl-copy:img', function(){
   return gulp.src('**/*.*',{cwd: resolvePath(paths().source.images)} )
     .pipe(gulp.dest(resolvePath(paths().public.images)));
+gulp.task('pl-copy:img', function () {
 });
 
 // Favicon copy
-gulp.task('pl-copy:favicon', function(){
   return gulp.src('favicon.ico', {cwd: resolvePath(paths().source.root)} )
     .pipe(gulp.dest(resolvePath(paths().public.root)));
+gulp.task('pl-copy:favicon', function () {
 });
 
 // Fonts copy
-gulp.task('pl-copy:font', function(){
   return gulp.src('*', {cwd: resolvePath(paths().source.fonts)})
     .pipe(gulp.dest(resolvePath(paths().public.fonts)));
+gulp.task('pl-copy:font', function () {
 });
 
 // CSS Copy
-gulp.task('pl-copy:css', function(){
   return gulp.src(resolvePath(paths().source.css) + '/*.css')
     .pipe(gulp.dest(resolvePath(paths().public.css)))
+gulp.task('pl-copy:css', function () {
     .pipe(browserSync.stream());
 });
 
 // Styleguide Copy everything but css
-gulp.task('pl-copy:styleguide', function(){
   return gulp.src(resolvePath(paths().source.styleguide) + '/**/!(*.css)')
     .pipe(gulp.dest(resolvePath(paths().public.root)))
+gulp.task('pl-copy:styleguide', function () {
     .pipe(browserSync.stream());
 });
 
 // Styleguide Copy and flatten css
-gulp.task('pl-copy:styleguide-css', function(){
   return gulp.src(resolvePath(paths().source.styleguide) + '/**/*.css')
     .pipe(gulp.dest(function(file){
+gulp.task('pl-copy:styleguide-css', function () {
       //flatten anything inside the styleguide into a single output dir per http://stackoverflow.com/a/34317320/1790362
       file.path = path.join(file.base, path.basename(file.path));
       return resolvePath(path.join(paths().public.styleguide, '/css'));
@@ -205,8 +205,8 @@ gulp.task('patternlab:connect', gulp.series(function(done) {
         'text-align: center'
       ]
     }
-  }, function(){
     console.log('PATTERN LAB NODE WATCHING FOR CHANGES');
+  }, function () {
     done();
   });
 }));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,24 +79,32 @@ function getConfiguredCleanOption() {
   return config.cleanPublic;
 }
 
-function build() {
-  return patternlab.build(() => {}, getConfiguredCleanOption());
+/**
+ *
+ * @param {function} done - Gulp done callback
+ */
+function build(done) {
+  const buildPromise = patternlab.build(() => {}, getConfiguredCleanOption());
+
+  // handle async version of Pattern Lab
+  if (buildPromise instanceof Promise) {
+    return buildPromise.then(done);
+  }
+
+  // handle sync version of Pattern Lab
+  done();
+  return null;
 }
 
-gulp.task('pl-assets', gulp.series(
-  gulp.parallel(
-    'pl-copy:js',
-    'pl-copy:img',
-    'pl-copy:favicon',
-    'pl-copy:font',
-    'pl-copy:css',
-    'pl-copy:styleguide',
-    'pl-copy:styleguide-css'
-  ),
-  function(done){
-    done();
-  })
-);
+gulp.task('pl-assets', gulp.parallel(
+  'pl-copy:js',
+  'pl-copy:img',
+  'pl-copy:favicon',
+  'pl-copy:font',
+  'pl-copy:css',
+  'pl-copy:styleguide',
+  'pl-copy:styleguide-css'
+));
 
 gulp.task('patternlab:version', function (done) {
   patternlab.version();
@@ -122,7 +130,7 @@ gulp.task('patternlab:loadstarterkit', function (done) {
   done();
 });
 
-gulp.task('patternlab:build', gulp.series('pl-assets', build));
+gulp.task('patternlab:build', gulp.parallel('pl-assets', build));
 
 gulp.task('patternlab:installplugin', function (done) {
   patternlab.installplugin(argv.plugin);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -209,6 +209,7 @@ function watch() {
         normalizePath(paths().source.data, '**', '*.json'),
         normalizePath(paths().source.fonts, '**', '*'),
         normalizePath(paths().source.images, '**', '*'),
+        normalizePath(paths().source.js, '**', '*'),
         normalizePath(paths().source.meta, '**', '*'),
         normalizePath(paths().source.annotations, '**', '*')
       ].concat(getTemplateWatches()),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,7 @@ gulp.task('patternlab:loadstarterkit', function (done) {
   done();
 });
 
-gulp.task('patternlab:build', gulp.parallel('pl-assets', build));
+gulp.task('patternlab:build', gulp.series('pl-assets', build));
 
 gulp.task('patternlab:installplugin', function (done) {
   patternlab.installplugin(argv.plugin);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -218,11 +218,11 @@ function watch() {
     }
   ];
 
-  for (const watcher of watchers) {
+  watchers.forEach(watcher => {
     console.log('\n' + chalk.bold('Watching ' + watcher.name + ':'));
     watcher.paths.forEach(p => console.log('  ' + p));
     gulp.watch(watcher.paths, watcher.config, watcher.tasks);
-  }
+  });
   console.log();
 }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "bugs": "https://github.com/pattern-lab/edition-node-gulp/issues",
   "author": "Brian Muenzenmeyer",
   "scripts": {
-    "start": "node_modules/gulp/bin/gulp.js patternlab:serve",
+    "start": "gulp patternlab:serve",
     "postinstall": "node scripts/postinstall.js",
     "gulp": "gulp -- "
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "bugs": "https://github.com/pattern-lab/edition-node-gulp/issues",
   "author": "Brian Muenzenmeyer",
   "scripts": {
+    "start": "node_modules/gulp/bin/gulp.js patternlab:serve",
     "postinstall": "node scripts/postinstall.js",
     "gulp": "gulp -- "
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.3.4",
   "dependencies": {
     "browser-sync": "^2.0.0",
+    "chalk": "^1.1.3",
     "gulp": "gulpjs/gulp#4.0",
     "minimist": "^1.2.0",
     "patternlab-node": "^2.0.0",


### PR DESCRIPTION
This adds support for the ongoing async build work in the PL / Node core, and should fix #82. Includes changes from https://github.com/pattern-lab/edition-node-gulp/pull/92.

I also recently ran into some major file watching reliability issues on Mac and Linux during a deployment of a fresh Pattern Lab instance. In one case, the reload() tasks would never complete, leaving the watcher dead after the first reload. In all cases, new and deleted files were not detected. So I decided to fix up file watching and see if I could get it rock solid.

In research, I discovered that gulp.watch() is (or has been historically) sensitive to paths beginning with `./`, and may not work with absolute paths! I tried normalizing all paths to relative before feeding them into the watchers, and now they seem much happier. Just using the watcher callback, instead of catching the 'change' event on the stream also picks up new and deleted files.

With this change set, we have:
* 'npm start' will now execute `node_modules/gulp/bin/gulp.js patternlab:serve`, making global gulp-cli optional
* Support for es6 syntax in the linter
* Watch the JS file directory
* Async build support, backwards-compatible with sync versions of PL
* Normalize all paths to relative. This works around some limitations in gulp.watch()
* Detect new and deleted files
* Make the reload functions use done callbacks, as their tasks were sometimes not completing
* Organize and report file watching groups to promote user confidence in the intent of the watcher

This seems to work very reliably for on Linux with Node 6.9. I'm going to test on Mac OS tomorrow. It could use a review and a Windows test as well.

Feedback is welcome as always, and I apologize if I've stepped on any toes.