### PR TITLE
Add option to not open browser on start

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -235,6 +235,7 @@ gulp.task('patternlab:connect', gulp.series(function (done) {
       // Ignore all HTML files within the templates folder
       blacklist: ['/index.html', '/', '/?*']
     },
+    open: (argv.noopen ? false : true),
     notify: {
       styles: [
         'display: none',


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Summary of changes:
* Add option to prevent automatic opening of browser when starting.

This small changes makes it possible to add the the option `--noopen` to:
```
gulp patternlab:serve --noopen
```
to prevent browsersync from opening to browser when Patternlab starts. The default is `true`, so nothing is different if you don't use the flag.