### PR TITLE
No need to declare node_modules dir in require

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -160,7 +160,7 @@ gulp.task('patternlab:installplugin', function (done) {
 ******************************************************/
 // watch task utility functions
 function getSupportedTemplateExtensions() {
-  var engines = require('./node_modules/patternlab-node/core/lib/pattern_engines');
+  var engines = require('patternlab-node/core/lib/pattern_engines');
   return engines.getSupportedFileExtensions();
 }
 function getTemplateWatches() {


### PR DESCRIPTION
Hi,

'node_modules' dir no need to be specified when require 'pattern_engines'.
Can cause a fatal error (no path found) when we need to launch gulp tasks out of root project like this (patternlab installed as a node dependency) :
```bash
gulp --cwd . --gulpfile node_modules/edition-node-gulp/gulpfile.js
```

Regards.
