### PR TITLE
Recursively copy fonts to public folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,7 @@ gulp.task('pl-copy:favicon', function () {
 
 // Fonts copy
 gulp.task('pl-copy:font', function () {
-  return gulp.src('*', {cwd: normalizePath(paths().source.fonts)})
+  return gulp.src('**/*.*', {cwd: normalizePath(paths().source.fonts)})
     .pipe(gulp.dest(normalizePath(paths().public.fonts)));
 });
 


### PR DESCRIPTION
If you have several fonts sitting in different folders they will not be published as the Gulp task only takes first-level children. Using `**/*.*` instead allows more granularity.